### PR TITLE
Added robustness to the datastore libraries.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -31,14 +31,14 @@ spec:
     spec:
       containers:
         - name: {site}-{node}-{experiment}-{rsync_module}
-          image: gcr.io/mlab-staging/github-pboothe-scraper:ab247f07ca86744d0ac837098c32d3fc8286ef6f
+          image: gcr.io/mlab-sandbox/github-pboothe-scraper-fix-mem-pressure:b4a744e88ed48ed4fa055ebf49d99d824ebcf9bf
           env:
             - name: RSYNC_MODULE
               value: {rsync_module}
             - name: RSYNC_HOST
               value: {rsync_host}
             - name: GCS_BUCKET
-              value: mlab-scraper-staging
+              value: mlab-scraper-sandbox
             - name: DATASTORE_NAMESPACE
               value: scraper
           resources:


### PR DESCRIPTION
Now that ENOMEM isn't killing things, the flakiness of the datastore
service is biting us.  Apparently sometimes the login token just dies and
the query needs to be retried.  Scraper now does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/18)
<!-- Reviewable:end -->
