### PR TITLE
Fix mem pressure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: pip
 python: "2.7"
 sudo: required
 install:
+  - apt-get install -y nocache
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python: "2.7"
 sudo: required
+dist: trusty
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y nocache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: python
 cache: pip
 python: "2.7"
 sudo: required
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y nocache
 install:
-  - apt-get install -y nocache
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt
   - pip install coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ ADD scraper.py /scraper.py
 RUN chmod +x /scraper.py
 ADD run_scraper.py /run_scraper.py
 RUN chmod +x run_scraper.py
-ADD scraper_test.py /scraper_test.py
-ADD test-requirements.txt /test-requirements.txt
-RUN pip install -r test-requirements.txt
 # The monitoring port
 EXPOSE 9090
 # All daemons must be started here, along with the job they support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ADD scraper.py /scraper.py
 RUN chmod +x /scraper.py
 ADD run_scraper.py /run_scraper.py
 RUN chmod +x run_scraper.py
+ADD scraper_test.py /scraper_test.py
+ADD test-requirements.txt /test-requirements.txt
+RUN pip install -r test-requirements.txt
 # The monitoring port
 EXPOSE 9090
 # All daemons must be started here, along with the job they support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/cloud-sdk
 MAINTAINER Peter Boothe <pboothe@google.com>
 # Install all the standard packages we need
-RUN apt-get update && apt-get install -y rsync tar python-dev python-pip
+RUN apt-get update && apt-get install -y rsync tar python-dev python-pip nocache
 # Install all the python requirements
 ADD requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
@@ -13,7 +13,7 @@ RUN chmod +x run_scraper.py
 # The monitoring port
 EXPOSE 9090
 # All daemons must be started here, along with the job they support.
-CMD /run_scraper.py \
+CMD nocache /run_scraper.py \
     --rsync_host=$RSYNC_HOST \
     --rsync_module=$RSYNC_MODULE \
     --bucket=$GCS_BUCKET \

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ course, need your own cluster!  I created the cluster in staging with the
 following command line:
 ```bash
 gcloud container \
-  --project "mlab-staging" clusters create "scraper-staging-cluster" \
+  --project "mlab-sandbox" clusters create "scraper-cluster" \
   --zone "us-central1-a" \
   --machine-type "n1-standard-1" \
   --image-type "GCI" \
-  --disk-size "100" \
-  --scopes "https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append","https://www.googleapis.com/auth/spreadsheets" \
-  --num-nodes "75" \
+  --disk-size "50" \
+  --scopes "https://www.googleapis.com/auth/cloud-platform","https://www.googleapis.com/auth/spreadsheets" \
+  --num-nodes "100" \
   --network "default" \
   --enable-cloud-logging \
   --no-enable-cloud-monitoring

--- a/deploy.yml
+++ b/deploy.yml
@@ -43,5 +43,5 @@ spec:
               value: scraper
           resources:
             requests:
-              memory: "20Mi"
+              memory: "100Mi"
               cpu: "20m"

--- a/deploy.yml
+++ b/deploy.yml
@@ -31,14 +31,14 @@ spec:
     spec:
       containers:
         - name: {site}-{node}-{experiment}-{rsync_module}
-          image: gcr.io/mlab-staging/github-pboothe-scraper:ab247f07ca86744d0ac837098c32d3fc8286ef6f
+          image: gcr.io/mlab-sandbox/github-pboothe-scraper-fix-mem-pressure:b4a744e88ed48ed4fa055ebf49d99d824ebcf9bf
           env:
             - name: RSYNC_MODULE
               value: {rsync_module}
             - name: RSYNC_HOST
               value: {rsync_host}
             - name: GCS_BUCKET
-              value: mlab-scraper-staging
+              value: mlab-scraper-sandbox
             - name: DATASTORE_NAMESPACE
               value: scraper
           resources:

--- a/deploy.yml
+++ b/deploy.yml
@@ -38,7 +38,7 @@ spec:
             - name: RSYNC_HOST
               value: {rsync_host}
             - name: GCS_BUCKET
-              value: mlab-scraper-sandbox
+              value: scraper-mlab-sandbox
             - name: DATASTORE_NAMESPACE
               value: scraper
           resources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fasteners
 google-api-python-client
 google-cloud-datastore
 prometheus_client
+retry

--- a/run_scraper.py
+++ b/run_scraper.py
@@ -171,6 +171,12 @@ def parse_cmdline(args):
         type=str,
         default='mlab-storage-scraper-test',
         help='The Google Cloud Storage bucket to upload to')
+    parser.add_argument(
+        '--nocache_binary',
+        metavar='NOCACHE',
+        type=str,
+        default='/usr/bin/nocache',
+        help='The location of the nocache binary')
     return parser.parse_args(args)
 
 
@@ -183,8 +189,7 @@ def main(argv):  # pragma: no cover
         try:
             logging.info('Scraping %s', rsync_url)
             with RSYNC_RUNS.time():
-                scraper.download(args.rsync_binary, rsync_url, status,
-                                 destination)
+                scraper.download(args, rsync_url, status, destination)
             with UPLOAD_RUNS.time():
                 scraper.upload_if_allowed(args, status, destination,
                                           storage_service)

--- a/scraper_test.py
+++ b/scraper_test.py
@@ -181,14 +181,17 @@ BADBADBAD
         files = ['2016/10/26/DNE1', '2016/10/26/DNE2']
 
         def verify_contents(args):
+            # Verify that the third-to-last argument to check_call is a filename
+            # that contains the right data (specifically, the filenames).  This
+            # test needs to be kept in sync with the order of command-line
+            # arguments passed to the rsync call.
             self.assertEqual(files,
                              [x.strip() for x in file(args[-3]).readlines()])
 
         patched_check_call.side_effect = verify_contents
         scraper.download_files('/usr/bin/nocache', '/bin/true', 'localhost/',
                                ['2016/10/26/DNE1', '2016/10/26/DNE2'], '/tmp')
-        self.assertTrue(patched_check_call.called)
-        self.assertEqual(patched_check_call.call_count, 1)
+        patched_check_call.assert_called_once()
 
     @freezegun.freeze_time('2016-01-28 09:45:01 UTC')
     def test_new_archived_date_after_8am(self):

--- a/scraper_test.py
+++ b/scraper_test.py
@@ -163,7 +163,8 @@ BADBADBAD
     @testfixtures.log_capture()
     def test_download_files_fails_and_dies(self, log):
         with self.assertRaises(SystemExit):
-            scraper.download_files('/bin/false', 'localhost/',
+            scraper.download_files('/usr/bin/nocache', '/bin/false',
+                                   'localhost/',
                                    ['2016/10/26/DNE1', '2016/10/26/DNE2'],
                                    '/tmp')
         self.assertIn('ERROR', [x.levelname for x in log.records])
@@ -171,7 +172,8 @@ BADBADBAD
     @testfixtures.log_capture()
     def test_download_files_with_empty_does_nothing(self, log):
         # If the next line doesn't raise SystemExit then the test passes
-        scraper.download_files('/bin/false', 'localhost/', [], '/tmp')
+        scraper.download_files('/usr/bin/nocache', '/bin/false', 'localhost/',
+                               [], '/tmp')
         self.assertIn('WARNING', [x.levelname for x in log.records])
 
     @mock.patch.object(subprocess, 'check_call')
@@ -180,10 +182,10 @@ BADBADBAD
 
         def verify_contents(args):
             self.assertEqual(files,
-                             [x.strip() for x in file(args[2]).readlines()])
+                             [x.strip() for x in file(args[-3]).readlines()])
 
         patched_check_call.side_effect = verify_contents
-        scraper.download_files('/bin/true', 'localhost/',
+        scraper.download_files('/usr/bin/nocache', '/bin/true', 'localhost/',
                                ['2016/10/26/DNE1', '2016/10/26/DNE2'], '/tmp')
         self.assertTrue(patched_check_call.called)
         self.assertEqual(patched_check_call.call_count, 1)
@@ -280,7 +282,7 @@ BADBADBAD
                 file('2016/01/28/test1.txt', 'w').write('hello')
                 file('2016/01/28/test2.txt', 'w').write('goodbye')
                 scraper.create_tarfile(
-                    '/bin/tar', 'test.tgz',
+                    '/usr/bin/nocache', '/bin/tar', 'test.tgz',
                     ['2016/01/28/test1.txt', '2016/01/28/test2.txt'])
                 shutil.rmtree('2016')
                 self.assertFalse(os.path.exists('2016'))
@@ -304,7 +306,7 @@ BADBADBAD
                 self.assertEqual(file('test.tgz').read(), 'in the way')
                 with self.assertRaises(SystemExit):
                     scraper.create_tarfile(
-                        '/bin/tar', 'test.tgz',
+                        '/usr/bin/nocache', '/bin/tar', 'test.tgz',
                         ['2016/01/28/test1.txt', '2016/01/28/test2.txt'])
         finally:
             shutil.rmtree(temp_d)
@@ -320,7 +322,7 @@ BADBADBAD
                 file('2016/01/28/test2.txt', 'w').write('goodbye')
                 with self.assertRaises(SystemExit):
                     scraper.create_tarfile(
-                        '/bin/false', 'test.tgz',
+                        '/usr/bin/nocache', '/bin/false', 'test.tgz',
                         ['2016/01/28/test1.txt', '2016/01/28/test2.txt'])
         finally:
             shutil.rmtree(temp_d)
@@ -337,7 +339,7 @@ BADBADBAD
                 with self.assertRaises(SystemExit):
                     # Executes successfully, but fails to create the tarfile.
                     scraper.create_tarfile(
-                        '/bin/true', 'test.tgz',
+                        '/usr/bin/nocache', '/bin/true', 'test.tgz',
                         ['2016/01/28/test1.txt', '2016/01/28/test2.txt'])
         finally:
             shutil.rmtree(temp_d)
@@ -356,13 +358,14 @@ BADBADBAD
                     self.assertFalse(os.path.exists('test3.txt'))
                     self.assertTrue(os.path.exists('test3.txt.gz'))
             files = [f for f, _t in scraper.create_temporary_tarfiles(
-                '/bin/tar', '/bin/gunzip', temp_d, datetime.date(2016, 1, 28),
-                'mlab9.dne04.measurement-lab.org', 'exper', 100000)]
+                '/usr/bin/nocache', '/bin/tar', '/bin/gunzip', temp_d,
+                datetime.date(2016, 1, 28), 'mlab9.dne04.measurement-lab.org',
+                'exper', 100000)]
             self.assertEqual(files,
                              ['20160128T000000Z-mlab9-dne04-exper-0000.tgz'])
             with scraper.chdir(temp_d):
                 gen = scraper.create_temporary_tarfiles(
-                    '/bin/tar', '/bin/gunzip', temp_d,
+                    '/usr/bin/nocache', '/bin/tar', '/bin/gunzip', temp_d,
                     datetime.date(2016, 1, 28),
                     'mlab9.dne04.measurement-lab.org', 'exper', 100000)
                 fname, _ = gen.next()
@@ -394,15 +397,16 @@ BADBADBAD
             # By setting the max filesize as 4 bytes, we will end up creating a
             # separate tarfile for each test file.
             files = [f for f, _t in scraper.create_temporary_tarfiles(
-                '/bin/tar', '/bin/gunzip', temp_d, datetime.date(2016, 1, 28),
-                'mlab9.dne04.measurement-lab.org', 'exper', 4)]
+                '/usr/bin/nocache', '/bin/tar', '/bin/gunzip', temp_d,
+                datetime.date(2016, 1, 28), 'mlab9.dne04.measurement-lab.org',
+                'exper', 4)]
             self.assertEqual(files, [
                 '20160128T000000Z-mlab9-dne04-exper-0000.tgz',
                 '20160128T000000Z-mlab9-dne04-exper-0001.tgz'
             ])
             with scraper.chdir(temp_d):
                 gen = scraper.create_temporary_tarfiles(
-                    '/bin/tar', '/bin/gunzip', temp_d,
+                    '/usr/bin/nocache', '/bin/tar', '/bin/gunzip', temp_d,
                     datetime.date(2016, 1, 28),
                     'mlab9.dne04.measurement-lab.org', 'exper', 4)
                 gen.next()
@@ -436,17 +440,16 @@ BADBADBAD
         self.assertEqual(client.get.call_count, 2)
 
     @testfixtures.log_capture()
-    def test_get_data_robustness(self, log):
+    def test_get_data_robustness(self, _log):
         client = mock.Mock()
         client.key.return_value = {}
         client.get.side_effect = [
             scraper.cloud_exceptions.ServiceUnavailable('one failure'), {}]
         status = scraper.SyncStatus(client, None, None)
         status.get_data()
-        self.assertIn('WARNING', [x.levelname for x in log.records])
 
     @testfixtures.log_capture()
-    def test_get_data_fails_eventually(self, log):
+    def test_get_data_fails_eventually(self, _log):
         client = mock.Mock()
         client.key.return_value = {}
         client.get.side_effect = scraper.cloud_exceptions.ServiceUnavailable(
@@ -454,8 +457,6 @@ BADBADBAD
         status = scraper.SyncStatus(client, None, None)
         with self.assertRaises(scraper.cloud_exceptions.ServiceUnavailable):
             status.get_data()
-        self.assertIn('WARNING', [x.levelname for x in log.records])
-        self.assertIn('ERROR', [x.levelname for x in log.records])
 
     @mock.patch.object(scraper.SyncStatus, 'get_data')
     def test_get_last_archived_date_from_status_default(self, patched_get):
@@ -511,17 +512,16 @@ BADBADBAD
         client.put.assert_called_once()
 
     @testfixtures.log_capture()
-    def test_update_data_robustness(self, log):
+    def test_update_data_robustness(self, _log):
         client = mock.Mock()
         client.get.return_value = None
         client.put.side_effect = [
             scraper.cloud_exceptions.ServiceUnavailable('one failure'), None]
         status = scraper.SyncStatus(client, None, None)
         status.update_data('key', 'value')
-        self.assertIn('WARNING', [x.levelname for x in log.records])
 
     @testfixtures.log_capture()
-    def test_update_data_eventually_fails(self, log):
+    def test_update_data_eventually_fails(self, _log):
         client = mock.Mock()
         client.get.return_value = None
         client.put.side_effect = scraper.cloud_exceptions.ServiceUnavailable(
@@ -529,8 +529,6 @@ BADBADBAD
         status = scraper.SyncStatus(client, None, None)
         with self.assertRaises(scraper.cloud_exceptions.ServiceUnavailable):
             status.update_data('key', 'value')
-        self.assertIn('WARNING', [x.levelname for x in log.records])
-        self.assertIn('ERROR', [x.levelname for x in log.records])
 
     def test_remove_datafiles_all_finished(self):
         try:
@@ -614,7 +612,8 @@ BADBADBAD
                 self.assertFalse(os.path.exists('test'))
                 self.assertEqual(
                     'test',
-                    scraper.attempt_decompression('/bin/gunzip', 'test.gz'))
+                    scraper.attempt_decompression('/usr/bin/nocache',
+                                                  '/bin/gunzip', 'test.gz'))
                 self.assertFalse(os.path.exists('test.gz'))
                 self.assertTrue(os.path.exists('test'))
         finally:
@@ -631,7 +630,8 @@ BADBADBAD
                 self.assertFalse(os.path.exists('test'))
                 self.assertEqual(
                     'test.gz',
-                    scraper.attempt_decompression('/bin/false', 'test.gz'))
+                    scraper.attempt_decompression('/usr/bin/nocache',
+                                                  '/bin/false', 'test.gz'))
         finally:
             shutil.rmtree(temp_d)
         self.assertIn('ERROR', [x.levelname for x in log.records])
@@ -647,7 +647,8 @@ BADBADBAD
                 self.assertFalse(os.path.exists('test'))
                 self.assertEqual(
                     'test.gz',
-                    scraper.attempt_decompression('/bin/true', 'test.gz'))
+                    scraper.attempt_decompression('/usr/bin/nocache',
+                                                  '/bin/true', 'test.gz'))
         finally:
             shutil.rmtree(temp_d)
         self.assertIn('ERROR', [x.levelname for x in log.records])
@@ -664,7 +665,8 @@ BADBADBAD
                 self.assertTrue(os.path.exists('test'))
                 self.assertEqual(
                     'test',
-                    scraper.attempt_decompression('/bin/gunzip', 'test.gz'))
+                    scraper.attempt_decompression('/usr/bin/nocache',
+                                                  '/bin/gunzip', 'test.gz'))
                 self.assertTrue(os.path.exists('test.gz'))
                 self.assertTrue(os.path.exists('test'))
         finally:


### PR DESCRIPTION
Fixes the memory pressure problem by using the nocache argument, which prevents the (many) disk pages that rsync touches from filling up buffer memory and causing every docker instance to use 1Gig of RAM.  This code successfully ran all weekend and settled down to ~80 Megs of RAM per instance.

Now that ENOMEM isn't killing things, the flakiness of the datastore service is biting us.  Apparently sometimes the login token just dies and the query needs to be retried.  Scraper now does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/19)
<!-- Reviewable:end -->
