### PR TITLE
Fix the last piece of rsync memory usage.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: {{site}}-{{node}}-{{experiment}}-{{rsync_module}}
-          image: gcr.io/mlab-sandbox/github-pboothe-scraper-fix-mem-pressure:a100a65390d89c27540c5959511227d2d67d0215
+          image: gcr.io/mlab-sandbox/github-pboothe-scraper-breakup-rsync:7a81bf4f8b991df75040f1c6dc3942944bffbb1b
           env:
             - name: RSYNC_MODULE
               value: {{rsync_module}}
@@ -46,4 +46,4 @@ spec:
           resources:
             requests:
               memory: "100Mi"
-              cpu: "20m"
+              cpu: "30m"

--- a/scraper.py
+++ b/scraper.py
@@ -172,7 +172,7 @@ def download_files(nocache_binary, rsync_binary, rsync_url, files, destination):
     """
     files = list(files)
     if len(files) == 0:
-        logging.warning('No files to be downloaded from %s', rsync_url)
+        logging.info('No files to be downloaded from %s', rsync_url)
         return
     # Rsync all the files passed in
     for start in range(0, len(files), FILES_PER_RSYNC_DOWNLOAD):

--- a/scraper_test.py
+++ b/scraper_test.py
@@ -170,11 +170,10 @@ BADBADBAD
         self.assertIn('ERROR', [x.levelname for x in log.records])
 
     @testfixtures.log_capture()
-    def test_download_files_with_empty_does_nothing(self, log):
+    def test_download_files_with_empty_does_nothing(self, _log):
         # If the next line doesn't raise SystemExit then the test passes
         scraper.download_files('/usr/bin/nocache', '/bin/false', 'localhost/',
                                [], '/tmp')
-        self.assertIn('WARNING', [x.levelname for x in log.records])
 
     @mock.patch.object(subprocess, 'check_call')
     def test_download_files(self, patched_check_call):


### PR DESCRIPTION
Also changes the strings stored in the file to be \0-delimited instead
of \n-delimited, getting rid of another vector for strange filenames to
(possibly) negatively affect the scraper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/22)
<!-- Reviewable:end -->
