### PR TITLE
Save unicode strings rather than str objects to cloud datastore

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -593,17 +593,17 @@ class SyncStatus(object):
 
     def update_last_archived_date(self, date):
         """Updates the date before which it is safe to delete data."""
-        date_str = 'x%d-%02d-%02d' % (date.year, date.month, date.day)
+        date_str = u'x%d-%02d-%02d' % (date.year, date.month, date.day)
         self.update_data(self.COLLECTION_KEY, date_str)
 
     def update_debug_message(self, message):
         """Updates the debug message in cloud datastore."""
-        self.update_data(self.DEBUG_MESSAGE_KEY, message)
+        self.update_data(self.DEBUG_MESSAGE_KEY, unicode(message, 'UTF-8'))
 
     def update_last_collection(self):
         """Updates the last collection time in cloud datastore."""
         text = datetime.datetime.utcnow().strftime('x%Y-%02m-%02d-%02H:%02M')
-        self.update_data(self.LAST_COLLECTION_KEY, text)
+        self.update_data(self.LAST_COLLECTION_KEY, unicode(text, 'UTF-8'))
 
     def update_mtime(self, mtime):
         """Updates the mtime column in cloud datastore."""

--- a/scraper_test.py
+++ b/scraper_test.py
@@ -527,7 +527,9 @@ BADBADBAD
         status = scraper.SyncStatus(None, None, None)
         status.update_last_archived_date(datetime.date(2012, 2, 29))
         patched_update.assert_called_once()
-        self.assertTrue('x2012-02-29' in patched_update.call_args[0])
+        self.assertTrue(u'x2012-02-29' in patched_update.call_args[0])
+        index = patched_update.call_args[0].index(u'x2012-02-29')
+        self.assertEqual(type(patched_update.call_args[0][index]), unicode)
 
     def test_update_data_no_value(self):
         client = mock.Mock()
@@ -598,6 +600,8 @@ BADBADBAD
         status.update_debug_message('msg')
         patched_update_data.assert_called_once_with(
             'errorsincelastsuccessful', 'msg')
+        self.assertEqual(type(patched_update_data.call_args[0][1]),
+                         unicode)
 
     @freezegun.freeze_time('2016-01-28 07:43:16 UTC')
     @mock.patch.object(scraper.SyncStatus, 'update_data')
@@ -606,6 +610,8 @@ BADBADBAD
         status.update_last_collection()
         patched_update_data.assert_called_once_with('lastcollectionattempt',
                                                     'x2016-01-28-07:43')
+        self.assertEqual(type(patched_update_data.call_args[0][1]),
+                         unicode)
 
     @mock.patch.object(scraper.SyncStatus, 'update_data')
     def test_update_mtime(self, patched_update_data):
@@ -626,6 +632,8 @@ BADBADBAD
         patched_update_data.assert_not_called()
         logger.error('BADNESS')
         patched_update_data.assert_called_once()
+        self.assertEqual(type(patched_update_data.call_args[0][1]),
+                         unicode)
 
     def test_attempt_decompression(self):
         try:


### PR DESCRIPTION
Fixes https://github.com/m-lab/scraper/issues/23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/24)
<!-- Reviewable:end -->
