### PR TITLE
Add scraper-node label and selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ gcloud container \
   --no-enable-cloud-monitoring
 
 gcloud --project=mlab-sandbox container node-pools create prometheus-pool \
-  --cluster=scraper-cluster
-  --num-nodes=2
+  --cluster=scraper-cluster \
+  --num-nodes=2 \
+  --node-labels=prometheus-node=true \
   --machine-type=n1-standard-8
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ gcloud container \
   --num-nodes "150" \
   --network "default" \
   --enable-cloud-logging \
+  --node-labels=scraper-node=true \
   --no-enable-cloud-monitoring
 
 gcloud --project=mlab-sandbox container node-pools create prometheus-pool \
   --cluster=scraper-cluster
-  --num-nodes=1
-  --machine-type=n1-standard-4
+  --num-nodes=2
+  --machine-type=n1-standard-8
 ```
 
 The cluster, once it is created (and this step need only be done once per

--- a/deploy.yml
+++ b/deploy.yml
@@ -33,6 +33,8 @@ spec:
         machine: {{machine}}
         rsync_module: {{rsync_module}}
     spec:
+      nodeSelector:
+        scraper-node: 'true'
       containers:
         - name: {{site_safe}}-{{node_safe}}-{{experiment_safe}}-{{rsync_module_safe}}
           image: # Travis or the human operator should fill this in


### PR DESCRIPTION
This change updates the commands for creating a scraper cluster to include `--node-labels` to limit scraper deployments to the default scraper node-pool. As well, this change adds the corresponding `nodeSelector` to the `deploy.yml` template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/46)
<!-- Reviewable:end -->
