### PR TITLE
Update the histogram buckets.

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -94,8 +94,7 @@ TARFILE_UPLOAD_TIME = prometheus_client.Histogram(
     buckets=TIME_BUCKETS)
 TARFILE_CHUNK_UPLOAD_TIME = prometheus_client.Histogram(
     'scraper_tarfile_chunk_upload_time_seconds',
-    'How long it took to upload each tarfile',
-    buckets=TIME_BUCKETS)
+    'How long it took to upload each tarfile chunk')
 # pylint: enable=no-value-for-parameter
 
 


### PR DESCRIPTION
Chunks now take less than a second to upload, so they should use the default bucket size which ranges from .005 to 7.5 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/57)
<!-- Reviewable:end -->
