### PR TITLE
Make rsync less brittle. Create fewer labels.

### DIFF
--- a/run_scraper.py
+++ b/run_scraper.py
@@ -187,7 +187,7 @@ def main(argv):  # pragma: no cover
             SCRAPER_SUCCESS.labels(message='success').inc()
         except scraper.RecoverableScraperException as error:
             logging.error('Scrape and upload failed: %s', error.message)
-            SCRAPER_SUCCESS.labels(message=str(error.message)).inc()
+            SCRAPER_SUCCESS.labels(message=str(error.prometheus_label)).inc()
         # In order to prevent a thundering herd of rsync jobs, we spread the
         # jobs around in a memoryless way.  By choosing our inter-job sleep
         # time from an exponential distribution, we ensure that the resulting


### PR DESCRIPTION
Fixes #59 and also makes it so that the disappearance of ephemeral files from the test directory doesn't crash the rsync job. Should reduce the file count on busy machines, as they are the ones with the longest downloads and therefore the ones where the files on the system are most likely to change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/60)
<!-- Reviewable:end -->
