### PR TITLE
Export file counts for every successfully uploaded day.

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -74,9 +74,9 @@ BYTES_UPLOADED = prometheus_client.Counter(
     'scraper_bytes_uploaded',
     'Total bytes uploaded to GCS',
     ['bucket'])
-FILES_UPLOADED = prometheus_client.Gauge(
+FILES_UPLOADED = prometheus_client.Counter(
     'scraper_files_uploaded',
-    'Total file count of the files uploaded to GCS over the last 7 days',
+    'Total file count of the test files uploaded to GCS',
     ['day_of_week'])
 # The prometheus_client libraries confuse the linter.
 # pylint: disable=no-value-for-parameter
@@ -940,10 +940,8 @@ def upload_up_to_date(args, sync_status, destination,
             total_daily_files += num_files
             BYTES_UPLOADED.labels(bucket=args.bucket).inc(
                 os.stat(tgz_filename).st_size)
-        # pylint: disable=no-member
         FILES_UPLOADED.labels(
-            day_of_week=day_of_week(day)).set(total_daily_files)
-        # pylint: enable=no-member
+            day_of_week=day_of_week(day)).inc(total_daily_files)
         sync_status.update_last_archived_date(day)
         if max_mtime is not None:
             sync_status.update_mtime(max_mtime)

--- a/scraper.py
+++ b/scraper.py
@@ -940,6 +940,9 @@ def upload_up_to_date(args, sync_status, destination,
             total_daily_files += num_files
             BYTES_UPLOADED.labels(bucket=args.bucket).inc(
                 os.stat(tgz_filename).st_size)
+        # The FILES_UPLOADED count should only be incremented once we are
+        # confident that we won't re-upload all the files. Therefore, update it
+        # immediately before or after we call update_last_archived_date().
         FILES_UPLOADED.labels(
             day_of_week=day_of_week(day)).inc(total_daily_files)
         sync_status.update_last_archived_date(day)

--- a/scraper_test.py
+++ b/scraper_test.py
@@ -574,6 +574,12 @@ class TestScraper(unittest.TestCase):
                 'ndt', '/tmp'),
             '/tmp/20150706T000000Z-mlab1-acc01-ndt-%04d.tgz')
 
+    def test_day_of_week(self):
+        self.assertEqual(scraper.day_of_week(datetime.date(2017, 6, 15)),
+                         'Thursday')
+        self.assertEqual(scraper.day_of_week(datetime.date(2017, 6, 16)),
+                         'Friday')
+
 
 class TestScraperInTempDir(unittest.TestCase):
 


### PR DESCRIPTION
This should allow us to check, after parsing, whether the number of files scraper thinks it saved is the same as the number of files the parser found and parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/68)
<!-- Reviewable:end -->
