### PR TITLE
Add rsync_host_module label to scraper_files_uploaded metric

### DIFF
--- a/scraper_test.py
+++ b/scraper_test.py
@@ -569,9 +569,7 @@ class TestScraper(unittest.TestCase):
     def test_create_tarfile_template(self):
         self.assertEqual(
             scraper.create_tarfilename_template(
-                datetime.date(2015, 7, 6),
-                'ndt.iupui.mlab1.acc01.measurement-lab.org',
-                'ndt', '/tmp'),
+                datetime.date(2015, 7, 6), 'mlab1', 'acc01', 'ndt', '/tmp'),
             '/tmp/20150706T000000Z-mlab1-acc01-ndt-%04d.tgz')
 
     def test_day_of_week(self):


### PR DESCRIPTION
This PR adds an additional lable to the `scraper_files_uploaded` to ease joining with the corresponding metric from the etl worker. The `rsync_host_module` label is easily reconstructed from the file name by the etl worker (See: https://github.com/m-lab/etl/pull/148)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/72)
<!-- Reviewable:end -->
