### PR TITLE
Added robustness to zero-length .gz files

### DIFF
--- a/validation/verify-old-vs-new-june2017.sh
+++ b/validation/verify-old-vs-new-june2017.sh
@@ -47,11 +47,15 @@ gzdiff ()
       then
         if ! zdiff -q ${oldfile} ${newfile}.gz
         then
-          # The zipped and unzipped new files both differ from the old file
+          # The zipped and unzipped new files both differ from the old file,
+          # therefore the data actually differs.
           echo FILES DIFFER: ${filename}
         fi
       else
-        # No .gz file exists and the raw new file differs from the old
+        # The newfile and oldfile differ, and appending .gz to the newfile
+        # doesn't produce the name of an existing file that might match despite
+        # the newfile and oldfile differing. Therefore, the data actually
+        # differs.
         echo FILES DIFFER: ${filename}
       fi
     fi

--- a/validation/verify-old-vs-new-june2017.sh
+++ b/validation/verify-old-vs-new-june2017.sh
@@ -24,31 +24,35 @@ gzdiff ()
   experiment=$4
   oldfile=${olddir}/${filename}
   newfile=${newdir}/${filename}
-  if [[ -e ${newfile}.gz ]] && [[ ! -e ${newfile} ]]
+  # Files in the old archives are uniformly uncompressed. Files in the new
+  # archives, particularly in early June, may or may not be compressed.  If
+  # there is a compressed file but no uncompressed one, then we should
+  # use the file that exists.
+  if [[ -e ${newfile}.gz && ! -e ${newfile} ]]
   then
     newfile=${newfile}.gz
   fi
-  if [[ -f ${oldfile} && -f ${newfile} ]]
+  if [[ ${experiment} == "sidestream" ]]
   then
-    if [[ ${experiment} == "sidestream" ]]
+    # Sidestream files are not compressed
+    lines=$(comm -2 -3 <(sort ${oldfile})  <(sort ${newfile}) | wc -l)
+    if [[ $lines != 0 ]]
     then
-      lines=$(comm -2 -3 <(sort ${oldfile})  <(sort ${newfile}) | wc -l)
-      if [[ $lines != 0 ]]
+      echo FILES DIFFER: ${filename}
+    fi
+  else
+    if ! zdiff -q ${oldfile} ${newfile}
+    then
+      if [[ -e ${newfile}.gz ]]
       then
-        echo FILES DIFFER: ${filename}
-      fi
-    else
-      if ! zdiff -q ${oldfile} ${newfile}
-      then
-        if [[ -e ${newfile}.gz ]]
+        if ! zdiff -q ${oldfile} ${newfile}.gz
         then
-          if ! zdiff -q ${oldfile} ${newfile}.gz
-	  then
-            echo FILES DIFFER: ${filename}
-          fi
-        else
+          # The zipped and unzipped new files both differ from the old file
           echo FILES DIFFER: ${filename}
         fi
+      else
+        # No .gz file exists and the raw new file differs from the old
+        echo FILES DIFFER: ${filename}
       fi
     fi
   fi
@@ -68,7 +72,7 @@ do
       do
         tar xfz ${tgz}
         rm ${tgz}
-        find . | sort > filelist.txt
+        find . -type f | sort > filelist.txt
       done
     popd
     pushd $new
@@ -78,7 +82,7 @@ do
       do
         tar xfz ${tgz}
         rm ${tgz}
-        find . | sort > filelist.txt
+        find . -type f | sort > filelist.txt
       done
     popd
     # Only print out files that are in the legacy but not the new one.  These

--- a/validation/verify-old-vs-new-june2017.sh
+++ b/validation/verify-old-vs-new-june2017.sh
@@ -23,12 +23,8 @@ gzdiff ()
   filename=$3
   experiment=$4
   oldfile=${olddir}/${filename}
-  if [[ -e ${oldfile}.gz ]]
-  then
-    oldfile=${oldfile}.gz
-  fi
   newfile=${newdir}/${filename}
-  if [[ -e ${newfile}.gz ]]
+  if [[ -e ${newfile}.gz ]] && [[ ! -e ${newfile} ]]
   then
     newfile=${newfile}.gz
   fi
@@ -44,7 +40,15 @@ gzdiff ()
     else
       if ! zdiff -q ${oldfile} ${newfile}
       then
-        echo FILES DIFFER: ${filename}
+        if [[ -e ${newfile}.gz ]]
+        then
+          if ! zdiff -q ${oldfile} ${newfile}.gz
+	  then
+            echo FILES DIFFER: ${filename}
+          fi
+        else
+          echo FILES DIFFER: ${filename}
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Our data has files that failed after the creation of the .gz file but before any writes to the same file.  This PR makes the verification script robust to that circumstance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/109)
<!-- Reviewable:end -->
