### PR TITLE
Update scraper deployment to use the "scraper" monitoring group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
     branch: master
 
 - provider: script
-  script: $TRAVIS_BUILD_DIR/operator/deploy_prometheus_targets.sh mlab-staging
+  script: $TRAVIS_BUILD_DIR/operator/deploy_prometheus_targets.sh mlab-staging scraper
   skip_cleanup: true
   on:
     repo: m-lab/scraper
@@ -45,7 +45,7 @@ deploy:
     tags: true
 
 - provider: script
-  script: $TRAVIS_BUILD_DIR/operator/deploy_prometheus_targets.sh mlab-oti
+  script: $TRAVIS_BUILD_DIR/operator/deploy_prometheus_targets.sh mlab-oti scraper
   skip_cleanup: true
   on:
     repo: m-lab/scraper


### PR DESCRIPTION
This change completes the update to separate scraper releases from the release of other prometheus monitoring. The scraper .travis deployment now uses the "scraper" monitoring group.

This separation guarantees that the prometheus targets deployed here match the ones used to deploy scraper without limiting the prometheus targets generated by other repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/205)
<!-- Reviewable:end -->
