### PR TITLE
Replace Mi units with M units to simplify reasoning

### DIFF
--- a/k8s/deploy_template.yml
+++ b/k8s/deploy_template.yml
@@ -69,10 +69,10 @@ spec:
               value: "/tmp"
           resources:
             requests:
-              memory: "200Mi"
+              memory: "200M"
               cpu: "30m"
             limits:
-              memory: "400Mi"
+              memory: "400M"
               cpu: "500m"
           volumeMounts:
           - mountPath: /scraper_data
@@ -86,10 +86,10 @@ spec:
             - containerPort: 9100
           resources:
             requests:
-              memory: "10Mi"
+              memory: "10M"
               cpu: "10m"
             limits:
-              memory: "10Mi"
+              memory: "10M"
               cpu: "10m"
           volumeMounts:
           - mountPath: /scraper_data


### PR DESCRIPTION
There's a bunch of unschedulable scrapers due to memory pressure. I'll allocate more nodes, but I'd also like to fix the M-vs-Mi thing to make calculating the total RAM required a bit easier (because RAM is requested from GCE in M and G not Mi or Gi)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/232)
<!-- Reviewable:end -->
