### PR TITLE
Increase node exporter memory limit to prevent OOM

### DIFF
--- a/k8s/deploy_template.yml
+++ b/k8s/deploy_template.yml
@@ -89,7 +89,7 @@ spec:
               memory: "10M"
               cpu: "10m"
             limits:
-              memory: "10M"
+              memory: "30M"
               cpu: "10m"
           volumeMounts:
           - mountPath: /scraper_data


### PR DESCRIPTION
This change increases the memory limit on the node exporter container to prevent OOM restarts on that container.

Kubernetes schedules pods based on the resource requests, so this is not expected to impact scheduling or reserved resource allocation. However, this change should provide greater headroom for the node exporter to prevent OOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/scraper/276)
<!-- Reviewable:end -->
